### PR TITLE
CU-2bcpv8_Increase-cookie-session-max-age-to-8-hrs

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,7 +37,7 @@ app
 				},
 			}),
 			cookie: {
-				maxAge: 8 * 3600,
+				maxAge:  8 * 3600 * 1000,
 				sameSite: 'strict',
 				secure: process.env.NODE_ENV === 'production',
 			},


### PR DESCRIPTION
#### What does this PR do?
This PR increases the expiration time of the cookie session to 8 hrs.

#### Description of Task to be completed?
- Set cookie `maxAge` to `28800000`.

#### How should this be manually tested?
Clone this branch. 
Run `cd Github-Timeline-Backend`.
Run `yarn install` to install the dependencies. 
Run `yarn test` to run the tests.

#### Any background context you want to provide?

Screenshots (if appropriate)

Questions:
